### PR TITLE
chore: update kong/semver module path and prepare for release

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/blang/semver"
+	"github.com/kong/semver"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/blang/semver
+module github.com/kong/semver
 
 go 1.14

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "name": "semver",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.6.1-4digit"
+  "version": "4.0.0+4-digit"
 }
 

--- a/v4/examples/main.go
+++ b/v4/examples/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
+	"github.com/kong/semver/v4"
 )
 
 func main() {

--- a/v4/go.mod
+++ b/v4/go.mod
@@ -1,3 +1,3 @@
-module github.com/blang/semver/v4
+module github.com/kong/semver/v4
 
 go 1.14


### PR DESCRIPTION
This updates the module path allows for directing importing of kong/semver without replace rules in `go.mod` for the consuming application. This also prepares for a tag creation `v4.0.0+4-digit` which can be used to get the module into the application.